### PR TITLE
NickNameChooser avatar fix

### DIFF
--- a/src/Controller/NicknameChooser.php
+++ b/src/Controller/NicknameChooser.php
@@ -87,7 +87,7 @@ class NicknameChooser
              SUBSTRING(id::text, 10, 3),'/',
              SUBSTRING(id::text, 13, 3),'/',
              SUBSTRING(id::text, 16, 3),'/original/', avatar_file_name) AS avatar_uri
-             FROM accounts WHERE lower(username) IN ($placeholders)",
+             FROM accounts WHERE lower(username) IN ($placeholders) AND domain IS NULL",
              $values
                 );
         $query->execute();


### PR DESCRIPTION
Make sure that the avatar of the local user is fetched from the database. Remote users can have the same nickname as local users, causing the wrong avatar URL to be constructed in the nickname chooser